### PR TITLE
feat: add basic page table of contents template (EN)

### DIFF
--- a/templates/english/basic-page-template-table-of-contents.html
+++ b/templates/english/basic-page-template-table-of-contents.html
@@ -1,0 +1,159 @@
+<!-- TO DO: Remove all comments before deploying your code to production. -->
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <!-- TO DO: Add a description of the page for better SEO and sharing previews. -->
+    <meta
+      name="description"
+      content="Add a description to provide a brief summary of the content."
+    />
+
+    <!-- TO DO: Insert a concise, descriptive title that summarizes your page's content. -->
+    <title>Basic Page Template (EN)</title>
+
+    <!---------- GC Design System Utility ---------->
+    <!-- TO DO: Update the version number to receive future updates of the utility framework. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-utility/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.3.0/dist/gcds-utility.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TO DO: Update the version number to receive future updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.esm.js"
+    ></script>
+    <script
+      nomodule
+      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TO DO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="path/to/custom.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- TO DO: Modify the lang-href to set the language toggle's URL. -->
+    <!-- TO DO: Update the skip-to-href with the main content container's id. -->
+    <gcds-header lang-href="#" skip-to-href="#main-content">
+      <!-- The slot="search" attribute adds the search component to the header. -->
+      <gcds-search slot="search"></gcds-search>
+
+      <!-- The slot="breadcrumb" attribute adds the breadcrumbs component to the header. -->
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TO DO: Adjust the breadcrumb links with the correct ones for your site. -->
+        <gcds-breadcrumbs-item href="#">Link</gcds-breadcrumbs-item>
+        <gcds-breadcrumbs-item href="#">Link</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <!-- TO DO: Confirm the id matches the "skip-to-href" id in the header. -->
+    <gcds-container
+      id="#main-content"
+      main-container
+      size="xl"
+      centered
+      tag="main"
+    >
+      <!-- TO DO: Update the heading and text content. -->
+      <section>
+        <gcds-heading tag="h1">
+          Basic page with in-page table of contents
+        </gcds-heading>
+        <gcds-text>
+          This is an optional intro text before the table of contents.
+        </gcds-text>
+      </section>
+
+      <section>
+        <gcds-heading tag="h2">On this page</gcds-heading>
+        <!-- TO DO: Adjust the link id's with the correct id for each section. -->
+        <ul class="list-disc mb-400">
+          <li class="mb-100">
+            <gcds-link href="#section-1">Section 1</gcds-link>
+          </li>
+          <li class="mb-100">
+            <gcds-link href="#section-2">Section 2</gcds-link>
+          </li>
+          <li>
+            <gcds-link href="#section-3">Section 3</gcds-link>
+          </li>
+        </ul>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- TO DO: Confirm the id matches the "href" id in the corresponding "On this page" link. -->
+      <section id="section-1">
+        <gcds-heading tag="h2">Section 1</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+
+        <gcds-heading tag="h3">Sub-section heading</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+
+        <gcds-heading tag="h3">Sub-section heading</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- TO DO: Confirm the id matches the "href" id in the corresponding "On this page" link. -->
+      <section id="section-2">
+        <gcds-heading tag="h2">Section 2</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- TO DO: Confirm the id matches the "href" id in the corresponding "On this page" link. -->
+      <section id="section-3">
+        <gcds-heading tag="h2">Section 3</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- TO DO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2024-08-22</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TO DO: Update or remove the contextual footer heading and links as needed. -->
+    <gcds-footer
+      display="full"
+      contextual-heading="Canadian Digital Service"
+      contextual-links='{ "Why GC Notify": "#","Features": "#", "Activity on GC Notify": "#"}'
+    >
+    </gcds-footer>
+  </body>
+</html>


### PR DESCRIPTION
# Summary | Résumé

Adding the following new template:

- Basic page table of contents template (EN)

I'm still waiting on the FR translations for the new content but figured we could already get the EN template out the door.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1047)