### PR TITLE
feat: add basic page table of contents template (FR)

### DIFF
--- a/templates/english/basic-page-template-table-of-contents.html
+++ b/templates/english/basic-page-template-table-of-contents.html
@@ -62,7 +62,7 @@
     <!---------- Main content ---------->
     <!-- TO DO: Confirm the id matches the "skip-to-href" id in the header. -->
     <gcds-container
-      id="#main-content"
+      id="main-content"
       main-container
       size="xl"
       centered

--- a/templates/english/basic-page-template.html
+++ b/templates/english/basic-page-template.html
@@ -62,7 +62,7 @@
     <!---------- Main content ---------->
     <!-- TO DO: Confirm the id matches the "skip-to-href" id in the header. -->
     <gcds-container
-      id="#main-content"
+      id="main-content"
       main-container
       size="xl"
       centered

--- a/templates/french/basic-page-template-table-of-contents.html
+++ b/templates/french/basic-page-template-table-of-contents.html
@@ -1,0 +1,159 @@
+<!-- À faire : Enlever les commentaires avant de déployer votre code en production. -->
+<!DOCTYPE html>
+<html dir="ltr" lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <!-- À faire: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
+    <meta
+      name="description"
+      content="Ajouter une description qui résume brièvement le contenu."
+    />
+
+    <!-- À faire : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
+    <title>Modèle de page de base (FR)</title>
+
+    <!---------- GC Design System Utility ---------->
+    <!-- À faire : Mettre à jour le numéro de version pour recevoir les futures mises à jour du cadre utilitaire de Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-utility/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.3.0/dist/gcds-utility.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- À faire : Mettre à jour le numéro de version pour recevoir les futures mises à jour des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.esm.js"
+    ></script>
+    <script
+      nomodule
+      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.js"
+    ></script>
+
+    <!-- Styles personnalisés -->
+    <!-- À faire : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->
+    <!-- <link rel="stylesheet" href="path/to/custom.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- À faire : Modifier le lang-href pour définir l'URL de la bascule de langue. -->
+    <!-- À faire : Mettre à jour le skip-to-href avec l'attribut <id> du conteneur du contenu principal. -->
+    <gcds-header lang-href="#" skip-to-href="#main-content">
+      <!-- L'attribut slot="search" ajoute le composant recherche à l'en-tête. -->
+      <gcds-search slot="search"></gcds-search>
+
+      <!-- L'attribut slot="breadcrumb" ajoute le composant chemin de navigation à l'en-tête. -->
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!--À faire : Remplacer les liens du chemin de navigation avec les liens valides pour votre site. -->
+        <gcds-breadcrumbs-item href="#">Lien</gcds-breadcrumbs-item>
+        <gcds-breadcrumbs-item href="#">Lien</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <!-- À faire : Confirmez que l'attribut id correspond à l'attribut id de skip-to-href dans l'en-tête. -->
+    <gcds-container
+      id="main-content"
+      main-container
+      size="xl"
+      centered
+      tag="main"
+    >
+      <!-- À faire : Mettre à jour le contenu du titre et du texte. -->
+      <section>
+        <gcds-heading tag="h1">
+          Page de base avec table des matières intégrée
+        </gcds-heading>
+        <gcds-text>
+          Texte introductif facultatif précédant la table des matières.
+        </gcds-text>
+      </section>
+
+      <section>
+        <gcds-heading tag="h2">Sur cette page</gcds-heading>
+        <!-- À faire : Remplacer l'attribut id de chaque lien avec l'attribut id valide pour chaque section. -->
+        <ul class="list-disc mb-400">
+          <li class="mb-100">
+            <gcds-link href="#section-1">Section 1</gcds-link>
+          </li>
+          <li class="mb-100">
+            <gcds-link href="#section-2">Section 2</gcds-link>
+          </li>
+          <li>
+            <gcds-link href="#section-3">Section 3</gcds-link>
+          </li>
+        </ul>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- À faire : Vérifiez que l'attribut id correspond au id « href » du lien « Sur cette page » correspondant. -->
+      <section id="section-1">
+        <gcds-heading tag="h2">Section 1</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+
+        <gcds-heading tag="h3">Titre de la sous-section</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+
+        <gcds-heading tag="h3">Titre de la sous-section</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- À faire : Vérifiez que l'attribut id correspond au id « href » du lien « Sur cette page » correspondant. -->
+      <section id="section-2">
+        <gcds-heading tag="h2">Section 2</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- À faire : Vérifiez que l'attribut id correspond au id « href » du lien « Sur cette page » correspondant. -->
+      <section id="section-3">
+        <gcds-heading tag="h2">Section 3</gcds-heading>
+        <gcds-text>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
+          egestas maecenas pharetra convallis posuere morbi leo urna.
+        </gcds-text>
+      </section>
+
+      <!-- À faire : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
+      <gcds-date-modified>22-08-2024</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- À faire : Au besoin, mettre à jour ou enlever le titre et les liens de la bande contextuelle du pied de page. -->
+    <gcds-footer
+      display="full"
+      contextual-heading="Service numérique canadien"
+      contextual-links='{ "Pourquoi Notification GC": "#","Fonctionnalités": "#", "Activité sur Notification GC": "#"}'
+    >
+    </gcds-footer>
+  </body>
+</html>

--- a/templates/french/basic-page-template.html
+++ b/templates/french/basic-page-template.html
@@ -62,7 +62,7 @@
     <!---------- Main content ---------->
     <!-- À faire : Confirmez que l'attribut id correspond à l'attribut id de skip-to-href dans l'en-tête. -->
     <gcds-container
-      id="#main-content"
+      id="main-content"
       main-container
       size="xl"
       centered

--- a/templates/french/basic-page-template.html
+++ b/templates/french/basic-page-template.html
@@ -7,24 +7,24 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
     />
-    <!-- À faire: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les prévisualisations partagés. -->
+    <!-- À faire: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
     <meta
       name="description"
-      content="Ajouter une description qui fournit un bref aperçu du contenu."
+      content="Ajouter une description qui résume brièvement le contenu."
     />
 
     <!-- À faire : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
     <title>Modèle de page de base (FR)</title>
 
     <!---------- GC Design System Utility ---------->
-    <!-- À faire : Mettre à jour le numéro de version pour recevoir de mises à jour futurs du cadre utilitaire du Système de design GC. Tout changement important sera consigné dans le journal de modifications: https://github.com/cds-snc/gcds-utility/blob/main/CHANGELOG.md -->
+    <!-- À faire : Mettre à jour le numéro de version pour recevoir les futures mises à jour du cadre utilitaire de Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-utility/blob/main/CHANGELOG.md -->
     <link
       rel="stylesheet"
       href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.3.0/dist/gcds-utility.min.css"
     />
 
     <!---------- GC Design System Components ---------->
-    <!-- À faire : Mettre à jour le numéro de version pour recevoir de mises à jour futurs de Composants du Système de design GC. Tout changement important sera consigné dans le journal de modifications: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <!-- À faire : Mettre à jour le numéro de version pour recevoir les futures mises à jour des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
     <link
       rel="stylesheet"
       href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.25.0/dist/gcds/gcds.css"
@@ -45,22 +45,22 @@
 
   <body>
     <!---------- Header ---------->
-    <!-- À faire : Modifier le lang-href pour déterminer l'URL de la  bascule de langue. -->
-    <!-- À faire : Mettre à jour le skip-to-href avec l'attribut id du conteneur du contenu principal. -->
+    <!-- À faire : Modifier le lang-href pour définir l'URL de la bascule de langue. -->
+    <!-- À faire : Mettre à jour le skip-to-href avec l'attribut <id> du conteneur du contenu principal. -->
     <gcds-header lang-href="#" skip-to-href="#main-content">
-      <!-- L'attribut slot="search" ajoute le composant recherche dans l'en-tête. -->
+      <!-- L'attribut slot="search" ajoute le composant recherche à l'en-tête. -->
       <gcds-search slot="search"></gcds-search>
 
       <!-- L'attribut slot="breadcrumb" ajoute le composant chemin de navigation à l'en-tête. -->
       <gcds-breadcrumbs slot="breadcrumb">
-        <!--À faire :  Remplacer les liens du chemin de navigation avec ceux valides pour votre site. -->
+        <!--À faire : Remplacer les liens du chemin de navigation avec les liens valides pour votre site. -->
         <gcds-breadcrumbs-item href="#">Lien</gcds-breadcrumbs-item>
         <gcds-breadcrumbs-item href="#">Lien</gcds-breadcrumbs-item>
       </gcds-breadcrumbs>
     </gcds-header>
 
     <!---------- Main content ---------->
-    <!-- À faire : Confirmez que l'attribut id correspond à l'attribut "skip-to-href" dans l'en-tête. -->
+    <!-- À faire : Confirmez que l'attribut id correspond à l'attribut id de skip-to-href dans l'en-tête. -->
     <gcds-container
       id="#main-content"
       main-container
@@ -68,9 +68,9 @@
       centered
       tag="main"
     >
-      <!-- À faire : Mettre à jour le contenu de le titre et du texte. -->
+      <!-- À faire : Mettre à jour le contenu du titre et du texte. -->
       <section>
-        <gcds-heading tag="h1">Modèle de page de base</gcds-heading>
+        <gcds-heading tag="h1">Page de base</gcds-heading>
         <gcds-text>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Turp is
@@ -101,12 +101,12 @@
         </gcds-text>
       </section>
 
-      <!-- À faire : Mettre à jour la date pour refléter le changement le plus récent dans la page. -->
+      <!-- À faire : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
       <gcds-date-modified>22-08-2024</gcds-date-modified>
     </gcds-container>
 
     <!---------- Footer ---------->
-    <!-- TO DO: Update or remove the contextual footer heading and links as needed. -->
+    <!-- À faire : Au besoin, mettre à jour ou enlever le titre et les liens de la bande contextuelle du pied de page. -->
     <gcds-footer
       display="full"
       contextual-heading="Service numérique canadien"


### PR DESCRIPTION
# Summary | Résumé

Adding the following new template:

- Basic page table of contents template (FR)
- Updates to the FR comment translations after review

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1047)