### PR TITLE
fix: add homepage config to holiday app

### DIFF
--- a/fable-test-app/package.json
+++ b/fable-test-app/package.json
@@ -32,5 +32,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
-  }
+  },
+  "homepage": "."
 }


### PR DESCRIPTION
# Summary | Résumé
https://create-react-app.dev/docs/deployment/#building-for-relative-paths

Hopefully this fixes the asset path issue for github pages