### PR TITLE
ci: add public url to publish workflow

### DIFF
--- a/.github/workflows/publish-fable-test-app.yml
+++ b/.github/workflows/publish-fable-test-app.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Build Fable test app
         run: npm run build
+        env:
+          PUBLIC_URL: ${{ secrets.GH_PAGES_URL }}
         working-directory: ./fable-test-app
 
       - name: Deploy


### PR DESCRIPTION
# Summary | Résumé
Uses a secret for the public url env