### PR TITLE
fix: Source of github image on about page

### DIFF
--- a/fable-test-app/src/pages/About.tsx
+++ b/fable-test-app/src/pages/About.tsx
@@ -42,7 +42,7 @@ const About: React.FC = () => {
           cardTitleTag="h3"
           badge="Code"
           href="https://github.com/cds-snc/gcds-components"
-          imgSrc="github.png"
+          imgSrc="/github.png"
           imgAlt=""
         />
       </Grid>


### PR DESCRIPTION
# Summary | Résumé

The Github image on the about page of the fable test app wasn't loading properly, fixed the src path.
