### PR TITLE
fix(fable-test-app): fix wording for day or days

### DIFF
--- a/fable-test-app/src/components/NextHoliday.tsx
+++ b/fable-test-app/src/components/NextHoliday.tsx
@@ -51,6 +51,7 @@ const NextHoliday: React.FC<NextHolidayProps> = ({
   };
 
   const daysToNextHoliday = nextHoliday ? calcNextHoliday(nextHoliday.date) : null;
+  const dayOrDays = daysToNextHoliday === 1 ? 'day' : 'days';
 
   if (!nextHoliday) {
     return null;
@@ -64,7 +65,7 @@ const NextHoliday: React.FC<NextHolidayProps> = ({
         alt="Calendar icon with a clock in the bottom right corner."
       />
       <Text textRole="light" marginBottom="0">
-        <strong>Next holiday is {nextHoliday.nameEn} — that's {daysToNextHoliday} days away</strong>
+        <strong>Next holiday is {nextHoliday.nameEn} — that's {daysToNextHoliday} {dayOrDays} away</strong>
       </Text>
     </div>
   ) : isCurrentHoliday ? (
@@ -101,7 +102,7 @@ const NextHoliday: React.FC<NextHolidayProps> = ({
       </div>
       <div className="d-flex bg-primary md:align-items-center align-items-center text-light md:px-450 px-250 py-200">
         <Text textRole="light" marginBottom="0">
-          <strong>That's in {daysToNextHoliday} days!</strong>
+          <strong>That's in {daysToNextHoliday} {dayOrDays}!</strong>
         </Text>
         <img
           className="d-inline-block ms-400"


### PR DESCRIPTION
# Summary | Résumé
Fixes this:
![Screenshot 2024-12-30 at 9 53 19 AM](https://github.com/user-attachments/assets/9eb21684-3640-4cb5-ad7e-96e6c3922eeb)

![Screenshot 2024-12-30 at 9 53 45 AM](https://github.com/user-attachments/assets/8099ff9a-fb2c-4dee-b192-1e8109b55143)


to this:
![Screenshot 2024-12-30 at 9 54 28 AM](https://github.com/user-attachments/assets/e31318b5-922a-49c1-b021-a49bdec11bd2)

![Screenshot 2024-12-30 at 9 54 07 AM](https://github.com/user-attachments/assets/e7d00baf-0e41-4f9d-b43c-61a4046f6d6e)


⚠️ Code freeze: Do not merge before January 6
