### PR TITLE
fix: remove outdated GCDS file from basic template

### DIFF
--- a/templates/english/basic/basic-page-template.html
+++ b/templates/english/basic/basic-page-template.html
@@ -31,10 +31,6 @@
       type="module"
       src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.esm.js"
     ></script>
-    <script
-      nomodule
-      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.js"
-    ></script>
 
     <!-- Custom styles -->
     <!-- TODO: If needed, uncomment and link your custom CSS file here. -->

--- a/templates/english/basic/extensions/basic-page-template-table-of-contents.html
+++ b/templates/english/basic/extensions/basic-page-template-table-of-contents.html
@@ -23,17 +23,13 @@
 
     <!---------- GC Design System Components ---------->
     <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
-      <link
+    <link
       rel="stylesheet"
       href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.css"
     />
     <script
       type="module"
       src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.esm.js"
-    ></script>
-    <script
-      nomodule
-      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.js"
     ></script>
 
     <!-- Custom styles -->

--- a/templates/french/basic/basic-page-template.html
+++ b/templates/french/basic/basic-page-template.html
@@ -31,10 +31,6 @@
       type="module"
       src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.esm.js"
     ></script>
-    <script
-      nomodule
-      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.js"
-    ></script>
 
     <!-- Styles personnalisés -->
     <!--TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->

--- a/templates/french/basic/extensions/basic-page-template-table-of-contents.html
+++ b/templates/french/basic/extensions/basic-page-template-table-of-contents.html
@@ -31,10 +31,6 @@
       type="module"
       src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.esm.js"
     ></script>
-    <script
-      nomodule
-      src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@<version-number>/dist/gcds/gcds.js"
-    ></script>
 
     <!-- Styles personnalisés -->
     <!-- TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->


### PR DESCRIPTION
# Summary | Résumé

The dist/ folder on our gcds-components hasn't contained the gcds/gcds.js file since this commit [cds-snc/gcds-components@16732e5](https://github.com/cds-snc/gcds-components/commit/16732e5dc068cdb65d17f5485bb3189b2871836c). Removing the file from our basic page templates to avoid any confusion.