### PR TITLE
fix(fable-test-app): Formatting of time element used in gcds-table

### DIFF
--- a/fable-test-app/src/pages/Submissions.tsx
+++ b/fable-test-app/src/pages/Submissions.tsx
@@ -81,7 +81,7 @@ const submissionCell = (value: string) => {
 
 const dateCell = (value: string) => {
   return (
-    <time title={`${value}`}>
+    <time>
       {new Date(value).toLocaleString("en-CA", {
         year: "numeric",
         month: "short",


### PR DESCRIPTION
# Summary | Résumé

Remove the `title` attribute from the `time` element on the submissions page as Safari was having issues reading the element causing the date to be read multiple times.

## How to test

1. On `main` branch
2. Run `npm run dev`
3. Navigate to `/submissions`
4. Using VoiceOver in Safari, navigate to the an entry in the Date submitted column
5. Notice the date will be read out several times.
6. Switch to this branch
7. Repeat steps 2 to 4
8. Notice the date is only read out once
