### PR TITLE
feat(starter-apps): add basic HTML starter app

### DIFF
--- a/starter-apps/html/README.md
+++ b/starter-apps/html/README.md
@@ -1,0 +1,35 @@
+# HTML Starter App with GCDS Components
+
+This is a starter app that you can use to bootstrap your project using plain HTML and GCDS Components, loaded directly from the design system CDN. No build step, no bundler, no npm install required.
+
+## Project Structure
+
+A brief overview of the project structure:
+
+```graphql
+html-basic-template/              # Project root (plain HTML/CSS/JS)
+├── en/                           # English pages
+│   ├── about/
+│   │   ├── topic/
+│   │   │   └── index.html        # Nested topic page, demonstrates two-level breadcrumbs
+│   │   └── index.html            # About page
+│   ├── report-a-bug/
+│   │   └── index.html            # Report a bug form
+│   └── index.html                # Home page
+├── fr/                           # French pages, same structure as en/
+│   ├── a-propos/
+│   │   ├── sujet/
+│   │   │   └── index.html
+│   │   └── index.html
+│   ├── signaler-un-bug/
+│   │   └── index.html
+│   └── index.html
+├── 404.html                      # Not found page
+├── index.html                    # Redirects to en/
+├── report-a-bug.js               # Shared submit/validation logic for both language forms
+└── README.md                     # Project documentation
+```
+
+## Future / Planned
+
+The `html-basic-template` project is the first and default HTML starter template. It uses plain HTML/CSS/JS with no build tooling, to establish the base structure for GCDS HTML starter apps. Future variants like `html-ssg-template` will follow the same pattern using a static site generator for more advanced templating, while still outputting plain HTML.

--- a/starter-apps/html/html-basic-template/404.html
+++ b/starter-apps/html/html-basic-template/404.html
@@ -1,0 +1,71 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!-- TODO: Most static hosts (GitHub Pages, Netlify, S3, etc.) look for a single 404.html at the root as their default error page. Because there's no server-side locale detection here, this page includes English and French. If your host supports serving a locale-specific 404 (e.g. based on the request path), you can split this into en/404.html and fr/404.html instead. -->
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <meta name="description" content="Page not found." />
+
+    <title>Page not found - HTML Starter App</title>
+
+    <!---------- GC Design System CSS Shortcuts ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of the GC Design System CSS Shortcuts. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TODO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="path/to/custom.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <gcds-header lang-href="fr/" skip-to-href="#main-content">
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Top navigation">
+        <!-- TODO: Add/remove nav links to match your site's pages. -->
+        <gcds-nav-link slot="home" href="en/">Home</gcds-nav-link>
+        <gcds-nav-link href="en/about/">About</gcds-nav-link>
+        <gcds-nav-link href="en/report-a-bug/">Report a Bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <!-- No breadcrumbs on the 404 page. -->
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">
+          Page could not be found<br />Page introuvable
+        </gcds-heading>
+        <gcds-text>Check you've entered the correct web address.</gcds-text>
+        <gcds-text>
+          Assurez-vous d'avoir saisi la bonne adresse Web.
+        </gcds-text>
+      </section>
+
+      <!-- TODO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2026-08-04</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TODO: Add contextual-heading/contextual-links attributes if your site needs a contextual footer. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/README.md
+++ b/starter-apps/html/html-basic-template/README.md
@@ -1,0 +1,47 @@
+# HTML Starter App (Plain HTML) with GCDS Components
+
+This starter helps you bootstrap a plain HTML website using GC Design System components loaded directly from the [design system CDN](https://cdn.design-system.canada.ca/) — no build step, no bundler, no `npm install` required.
+
+If you want more advanced tooling (templating, partials, a build step) while still writing plain HTML/CSS/JS, see the upcoming static-site-generator variant of this starter (not yet available).
+
+## What this starter includes
+
+- Plain HTML pages using `<gcds-*>` web components from the CDN
+- Localized routing via folders/files (`en` / `fr`), matching the route contract below
+- Shared app shell (GCDS header, top navigation, breadcrumbs, container, footer)
+- Each page is a self-contained file
+- Sample pages (Home, About, About Topic, Report a Bug, Not Found)
+- A working Report a Bug form with client-side validation
+
+## Route contract
+
+- `/en/` and `/fr/`
+- `/en/about/` and `/fr/a-propos/`
+- `/en/about/topic/` and `/fr/a-propos/sujet/`
+- `/en/report-a-bug/` and `/fr/signaler-un-bug/`
+- `/404.html` (see the TODO comment in that file if your host supports locale-specific error pages)
+
+## Development
+
+There's nothing to install. Either:
+
+- Open `en/index.html` (or `fr/index.html`) directly in your browser, or
+- Serve the folder with any static file server, for example:
+  ```sh
+  npx serve .
+  ```
+
+## Keeping the CDN links up to date
+
+Every page links to a specific pinned version of `@gcds-core/components` and `@gcds-core/css-shortcuts`. Check the changelogs below periodically and update the version numbers in each HTML file:
+
+- [`@gcds-core/components` changelog](https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md)
+- [`@gcds-core/css-shortcuts` changelog](https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md)
+
+## Deploying
+
+This is plain static HTML. Deploy it to any static host (GitHub Pages, Netlify, S3, etc.). Remember to:
+
+- Remove the `<!-- TODO -->` comments before shipping to production
+- Configure your host to serve `404.html` as the error page
+- Consider a server-level redirect from `/` to `/en/` instead of the meta-refresh in [`index.html`](index.html), if your host supports it

--- a/starter-apps/html/html-basic-template/en/about/index.html
+++ b/starter-apps/html/html-basic-template/en/about/index.html
@@ -1,0 +1,79 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- TODO: Add a description of the page for better SEO and sharing previews. -->
+    <meta
+      name="description"
+      content="About page of the GCDS HTML starter app."
+    />
+
+    <title>About - HTML Starter App</title>
+
+    <!---------- GC Design System CSS Shortcuts ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of the GC Design System CSS Shortcuts. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TODO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- TODO: lang-href points to the French equivalent of this page. Update it if you change the route structure. -->
+    <gcds-header lang-href="../../fr/a-propos/" skip-to-href="#main-content">
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Top navigation">
+        <!-- TODO: Add/remove nav links to match your site's pages. -->
+        <gcds-nav-link slot="home" href="../">Home</gcds-nav-link>
+        <gcds-nav-link href="./" current>About</gcds-nav-link>
+        <gcds-nav-link href="../report-a-bug/">Report a Bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Adjust the breadcrumb links with the correct ones for your site. -->
+        <gcds-breadcrumbs-item href="../">Home</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">About</gcds-heading>
+        <gcds-text>
+          This HTML starter template integrates GC Design System components and
+          provides a solid foundation for building modern, responsive web
+          applications with consistent design and accessibility.
+        </gcds-text>
+
+        <gcds-link href="topic/">Topic</gcds-link>
+      </section>
+
+      <!-- TODO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2026-08-04</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TODO: Add contextual-heading/contextual-links attributes if your site needs a contextual footer. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/en/about/topic/index.html
+++ b/starter-apps/html/html-basic-template/en/about/topic/index.html
@@ -1,0 +1,80 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- TODO: Add a description of the page for better SEO and sharing previews. -->
+    <meta
+      name="description"
+      content="Topic page of the GCDS HTML starter app, nested under About."
+    />
+
+    <title>Topic - HTML Starter App</title>
+
+    <!---------- GC Design System CSS Shortcuts ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of the GC Design System CSS Shortcuts. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TODO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="../../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- TODO: lang-href points to the French equivalent of this page. Update it if you change the route structure. -->
+    <gcds-header
+      lang-href="../../../fr/a-propos/sujet/"
+      skip-to-href="#main-content"
+    >
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Top navigation">
+        <!-- TODO: Add/remove nav links to match your site's pages. -->
+        <gcds-nav-link slot="home" href="../../">Home</gcds-nav-link>
+        <gcds-nav-link href="../">About</gcds-nav-link>
+        <gcds-nav-link href="../../report-a-bug/">Report a Bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Adjust the breadcrumb links with the correct ones for your site. -->
+        <gcds-breadcrumbs-item href="../../">Home</gcds-breadcrumbs-item>
+        <gcds-breadcrumbs-item href="../">About</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Topic</gcds-heading>
+        <gcds-text>
+          This is a sample topic page inside a parent About page. It
+          demonstrates breadcrumb behavior across nested routes.
+        </gcds-text>
+      </section>
+
+      <!-- TODO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2026-08-04</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TODO: Add contextual-heading/contextual-links attributes if your site needs a contextual footer. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/en/index.html
+++ b/starter-apps/html/html-basic-template/en/index.html
@@ -1,0 +1,83 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- TODO: Add a description of the page for better SEO and sharing previews. -->
+    <meta
+      name="description"
+      content="Home page of the GCDS HTML starter app."
+    />
+
+    <title>Home - HTML Starter App</title>
+
+    <!---------- GC Design System CSS Shortcuts ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of the GC Design System CSS Shortcuts. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TODO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- TODO: lang-href points to the French equivalent of this page. Update it if you change the route structure. -->
+    <gcds-header lang-href="../fr/" skip-to-href="#main-content">
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Top navigation">
+        <!-- TODO: Add/remove nav links to match your site's pages. -->
+        <gcds-nav-link slot="home" href="./" current>Home</gcds-nav-link>
+        <gcds-nav-link href="about/">About</gcds-nav-link>
+        <gcds-nav-link href="report-a-bug/">Report a Bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <!-- No breadcrumbs on the home page. -->
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Home</gcds-heading>
+        <gcds-text>
+          Welcome to the HTML Starter App that leverages GC Design System
+          components!
+        </gcds-text>
+        <gcds-text>
+          This starter app template is designed to help developers quickly set
+          up a plain HTML site while adhering to the accessibility and design
+          standards set by the Government of Canada.
+        </gcds-text>
+        <gcds-text>
+          Every page is a standalone HTML file that loads GCDS components
+          directly from the CDN. No build step, no bundler, no npm install
+          required. Copy this folder, edit the HTML, and you're up and running.
+        </gcds-text>
+      </section>
+
+      <!-- TODO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2026-08-04</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TODO: Add contextual-heading/contextual-links attributes if your site needs a contextual footer. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/en/report-a-bug/index.html
+++ b/starter-apps/html/html-basic-template/en/report-a-bug/index.html
@@ -1,0 +1,203 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- TODO: Add a description of the page for better SEO and sharing previews. -->
+    <meta
+      name="description"
+      content="Report a bug against GC Design System from the HTML starter app."
+    />
+
+    <title>Report a Bug - HTML Starter App</title>
+
+    <!---------- GC Design System CSS Shortcuts ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of the GC Design System CSS Shortcuts. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- GC Design System Components ---------->
+    <!-- TODO: Replace <version-number> with the latest version number to receive corresponding updates of GC Design System Components. All notable changes will be documented in the changelog: https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Custom styles -->
+    <!-- TODO: If needed, uncomment and link your custom CSS file here. -->
+    <!-- <link rel="stylesheet" href="../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- Header ---------->
+    <!-- TODO: lang-href points to the French equivalent of this page. Update it if you change the route structure. -->
+    <gcds-header
+      lang-href="../../fr/signaler-un-bug/"
+      skip-to-href="#main-content"
+    >
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Top navigation">
+        <!-- TODO: Add/remove nav links to match your site's pages. -->
+        <gcds-nav-link slot="home" href="../">Home</gcds-nav-link>
+        <gcds-nav-link href="../about/">About</gcds-nav-link>
+        <gcds-nav-link href="./" current>Report a Bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Adjust the breadcrumb links with the correct ones for your site. -->
+        <gcds-breadcrumbs-item href="../">Home</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Main content ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Report a Bug</gcds-heading>
+        <gcds-text>
+          Create a report to help us improve GC Design System.
+        </gcds-text>
+
+        <!-- TODO: Check ../../report-a-bug.js for the submit handling. -->
+        <form name="bugReportForm" novalidate>
+          <gcds-error-summary listen></gcds-error-summary>
+
+          <gcds-input
+            id="version"
+            name="version"
+            label="GC Design System Components Package and Version"
+            hint="e.g. @gcds-core/components@1.x.x"
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-input
+            id="title"
+            name="title"
+            label="Title"
+            hint="Choose a title for your bug report"
+            placeholder="bug: "
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-textarea
+            id="currentBehavior"
+            name="currentBehavior"
+            label="Current Behavior"
+            hint="Describe the current behavior"
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="expectedBehavior"
+            name="expectedBehavior"
+            label="Expected Behavior"
+            hint="Describe the expected behavior"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="systemInfo"
+            name="systemInfo"
+            label="System Info"
+            hint="Provide information about your system"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="stepsToReproduce"
+            name="stepsToReproduce"
+            label="Steps to Reproduce"
+            hint="List the steps to reproduce"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-input
+            id="codeReproductionUrl"
+            name="codeReproductionUrl"
+            type="url"
+            label="Code Reproduction URL"
+            hint="Provide a URL to the code reproduction"
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-textarea
+            id="additionalInfo"
+            name="additionalInfo"
+            label="Additional Information"
+            hint="Provide any additional information"
+          ></gcds-textarea>
+
+          <gcds-button type="submit">Submit</gcds-button>
+        </form>
+      </section>
+
+      <!-- Confirmation view, shown by report-a-bug.js after a valid submit. -->
+      <section id="confirmation" hidden>
+        <gcds-heading tag="h2">Confirmation</gcds-heading>
+        <gcds-text>
+          <strong>GC Design System Components Package and Version:</strong>
+          <span data-confirm="version"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Title:</strong> <span data-confirm="title"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Current Behavior:</strong>
+          <span data-confirm="currentBehavior"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Expected Behavior:</strong>
+          <span data-confirm="expectedBehavior"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>System Info:</strong> <span data-confirm="systemInfo"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Steps to Reproduce:</strong>
+          <span data-confirm="stepsToReproduce"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Code Reproduction URL:</strong>
+          <span data-confirm="codeReproductionUrl"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Additional Information:</strong>
+          <span data-confirm="additionalInfo"></span>
+        </gcds-text>
+
+        <gcds-heading tag="h2">Start an issue on GitHub</gcds-heading>
+        <gcds-button
+          id="github-issue-link"
+          href="#"
+          type="link"
+          target="_blank"
+        >
+          Open issue on Github
+        </gcds-button>
+      </section>
+
+      <!-- TODO: Update the date to reflect the page's most recent change. -->
+      <gcds-date-modified>2026-08-04</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Footer ---------->
+    <!-- TODO: Add contextual-heading/contextual-links attributes if your site needs a contextual footer. -->
+    <gcds-footer display="full"></gcds-footer>
+
+    <script src="../../report-a-bug.js"></script>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/fr/a-propos/index.html
+++ b/starter-apps/html/html-basic-template/fr/a-propos/index.html
@@ -1,0 +1,82 @@
+<!--TODO : Enlever les commentaires avant de déployer votre code en production. -->
+<!doctype html>
+<html dir="ltr" lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!--TODO: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
+    <meta
+      name="description"
+      content="Page À propos de l'application de démarrage HTML du SDGC."
+    />
+
+    <!--TODO : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
+    <title>À propos - Application de démarrage HTML</title>
+
+    <!---------- Système de design GC Raccourcis CSS ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes de Raccourcis CSS du Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- Système de design GC ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Styles personnalisés -->
+    <!--TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->
+    <!-- <link rel="stylesheet" href="../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- En-tête ---------->
+    <!-- TODO: lang-href pointe vers la version française de cette page. Mettez-le à jour si vous modifiez la structure des routes. -->
+    <gcds-header lang-href="../../en/about/" skip-to-href="#main-content">
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Navigation supérieure">
+        <!-- TODO: Ajoutez ou supprimez des liens de navigation pour qu’ils correspondent aux pages de votre site. -->
+        <gcds-nav-link slot="home" href="../">Accueil</gcds-nav-link>
+        <gcds-nav-link href="./" current>À propos</gcds-nav-link>
+        <gcds-nav-link href="../signaler-un-bug/"
+          >Signaler un bug</gcds-nav-link
+        >
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Mettez à jour les liens du chemin de navigation pour qu’ils correspondent à votre site. -->
+        <gcds-breadcrumbs-item href="../">Accueil</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Contenu principal ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">À propos</gcds-heading>
+        <gcds-text>
+          Ce modèle de démarrage React intègre les composants de Système de
+          design GC et fournit une base solide pour créer des applications Web
+          modernes, réactives et accessibles, avec une conception cohérente.
+        </gcds-text>
+
+        <gcds-link href="sujet/">Sujet</gcds-link>
+      </section>
+
+      <!-- TODO : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
+      <gcds-date-modified>04-08-2026</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Pied de page ---------->
+    <!-- TODO: Ajoutez les attributs contextual-heading et contextual-links si votre site utilise un pied de page contextuel. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/fr/a-propos/sujet/index.html
+++ b/starter-apps/html/html-basic-template/fr/a-propos/sujet/index.html
@@ -1,0 +1,84 @@
+<!--TODO : Enlever les commentaires avant de déployer votre code en production. -->
+<!doctype html>
+<html dir="ltr" lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!--TODO: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
+    <meta
+      name="description"
+      content="Page Sujet de l'application de démarrage HTML du SDGC, imbriquée sous À propos."
+    />
+
+    <!--TODO : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
+    <title>Sujet - Application de démarrage HTML</title>
+
+    <!---------- Système de design GC Raccourcis CSS ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes de Raccourcis CSS du Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- Système de design GC ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Styles personnalisés -->
+    <!--TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->
+    <!-- <link rel="stylesheet" href="../../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- En-tête ---------->
+    <!-- TODO: lang-href pointe vers la version française de cette page. Mettez-le à jour si vous modifiez la structure des routes. -->
+    <gcds-header
+      lang-href="../../../en/about/topic/"
+      skip-to-href="#main-content"
+    >
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Navigation supérieure">
+        <!-- TODO: Ajoutez ou supprimez des liens de navigation pour qu’ils correspondent aux pages de votre site. -->
+        <gcds-nav-link slot="home" href="../../">Accueil</gcds-nav-link>
+        <gcds-nav-link href="../">À propos</gcds-nav-link>
+        <gcds-nav-link href="../../signaler-un-bug/"
+          >Signaler un bug</gcds-nav-link
+        >
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Mettez à jour les liens du chemin de navigation pour qu’ils correspondent à votre site. -->
+        <gcds-breadcrumbs-item href="../../">Accueil</gcds-breadcrumbs-item>
+        <gcds-breadcrumbs-item href="../">À propos</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Contenu principal ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Sujet</gcds-heading>
+        <gcds-text>
+          Voici un exemple de page Sujet à l'intérieur d'une page parent À
+          propos. Cette page montre le comportement du chemin de navigation pour
+          des pages imbriquées.
+        </gcds-text>
+      </section>
+
+      <!-- TODO : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
+      <gcds-date-modified>04-08-2026</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Pied de page ---------->
+    <!-- TODO: Ajoutez les attributs contextual-heading et contextual-links si votre site utilise un pied de page contextuel. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/fr/index.html
+++ b/starter-apps/html/html-basic-template/fr/index.html
@@ -1,0 +1,84 @@
+<!--TODO : Enlever les commentaires avant de déployer votre code en production. -->
+<!doctype html>
+<html dir="ltr" lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!--TODO: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
+    <meta
+      name="description"
+      content="Page d'accueil de l'application de démarrage HTML du SDGC."
+    />
+
+    <!--TODO : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
+    <title>Accueil - Application de démarrage HTML</title>
+
+    <!---------- Système de design GC Raccourcis CSS ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes de Raccourcis CSS du Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- Système de design GC ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Styles personnalisés -->
+    <!--TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->
+    <!-- <link rel="stylesheet" href="../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- En-tête ---------->
+    <!-- TODO: lang-href pointe vers la version française de cette page. Mettez-le à jour si vous modifiez la structure des routes. -->
+    <gcds-header lang-href="../en/" skip-to-href="#main-content">
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Navigation supérieure">
+        <!-- TODO: Ajoutez ou supprimez des liens de navigation pour qu’ils correspondent aux pages de votre site. -->
+        <gcds-nav-link slot="home" href="./" current>Accueil</gcds-nav-link>
+        <gcds-nav-link href="a-propos/">À propos</gcds-nav-link>
+        <gcds-nav-link href="signaler-un-bug/">Signaler un bug</gcds-nav-link>
+      </gcds-top-nav>
+    </gcds-header>
+
+    <!---------- Contenu principal ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Accueil</gcds-heading>
+        <gcds-text>
+          Bienvenue dans l'application de démarrage HTML qui exploite les
+          composants du Système de design GC !
+        </gcds-text>
+        <gcds-text>
+          Ce modèle d'application de démarrage est conçu pour aider les
+          développeurs à configurer rapidement un site HTML simple tout en
+          adhérant aux normes d'accessibilité et de conception définies par le
+          gouvernement du Canada.
+        </gcds-text>
+        <gcds-text>
+          Chaque page est un fichier HTML autonome qui charge les composants
+          GCDS directement depuis le CDN — aucune étape de compilation, aucun
+          regroupeur, aucune installation npm requise. Copiez ce dossier,
+          modifiez le HTML, et c'est prêt.
+        </gcds-text>
+      </section>
+
+      <!-- TODO : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
+      <gcds-date-modified>04-08-2026</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Pied de page ---------->
+    <!-- TODO: Ajoutez les attributs contextual-heading et contextual-links si votre site utilise un pied de page contextuel. -->
+    <gcds-footer display="full"></gcds-footer>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/fr/signaler-un-bug/index.html
+++ b/starter-apps/html/html-basic-template/fr/signaler-un-bug/index.html
@@ -1,0 +1,208 @@
+<!--TODO : Enlever les commentaires avant de déployer votre code en production. -->
+<!doctype html>
+<html dir="ltr" lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!--TODO: Ajouter une description de la page pour améliorer le référencement naturel/SEO ainsi que les aperçus de partage. -->
+    <meta
+      name="description"
+      content="Signalez un bug du Système de design GC depuis l'application de démarrage HTML."
+    />
+
+    <!--TODO : Insérer un titre concis et descriptif qui résume le contenu de votre page. -->
+    <title>Signaler un bug - Application de démarrage HTML</title>
+
+    <!---------- Système de design GC Raccourcis CSS ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes de Raccourcis CSS du Système de design GC. Tout changement important sera consigné dans le journal des modifications: https://github.com/cds-snc/gcds-css-shortcuts/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@<version-number>/dist/gcds-css-shortcuts.min.css"
+    />
+
+    <!---------- Système de design GC ---------->
+    <!-- TODO : Remplacez <version-number> par le numéro de version le plus récent pour recevoir les mises à jour correspondantes des composants de Système de design GC. Tout changement important sera consigné dans le journal des modifications https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+    ></script>
+
+    <!-- Styles personnalisés -->
+    <!--TODO : Au besoin, décommenter et lier votre fichier CSS personnalisé ici. -->
+    <!-- <link rel="stylesheet" href="../../assets/styles.css" /> -->
+  </head>
+
+  <body>
+    <!---------- En-tête ---------->
+    <!-- TODO: lang-href pointe vers la version française de cette page. Mettez-le à jour si vous modifiez la structure des routes. -->
+    <gcds-header
+      lang-href="../../en/report-a-bug/"
+      skip-to-href="#main-content"
+    >
+      <gcds-search slot="search"></gcds-search>
+
+      <gcds-top-nav slot="menu" alignment="end" label="Navigation supérieure">
+        <!-- TODO: Ajoutez ou supprimez des liens de navigation pour qu’ils correspondent aux pages de votre site. -->
+        <gcds-nav-link slot="home" href="../">Accueil</gcds-nav-link>
+        <gcds-nav-link href="../a-propos/">À propos</gcds-nav-link>
+        <gcds-nav-link href="./" current>Signaler un bug</gcds-nav-link>
+      </gcds-top-nav>
+
+      <gcds-breadcrumbs slot="breadcrumb">
+        <!-- TODO: Mettez à jour les liens du chemin de navigation pour qu’ils correspondent à votre site. -->
+        <gcds-breadcrumbs-item href="../">Accueil</gcds-breadcrumbs-item>
+      </gcds-breadcrumbs>
+    </gcds-header>
+
+    <!---------- Contenu principal ---------->
+    <gcds-container id="main-content" layout="page" tag="main">
+      <section>
+        <gcds-heading tag="h1">Signaler un bug</gcds-heading>
+        <gcds-text>
+          Remplissez un rapport de bogue pour nous aider à améliorer le Système
+          de design GC.
+        </gcds-text>
+
+        <!-- TODO: Consultez ../../report-a-bug.js pour le traitement de la soumission. -->
+        <form name="bugReportForm" novalidate>
+          <gcds-error-summary listen></gcds-error-summary>
+
+          <gcds-input
+            id="version"
+            name="version"
+            label="Paquet et version des composants de Système de design GC"
+            hint="ex. @cdssnc/gcds-components@0.x.x"
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-input
+            id="title"
+            name="title"
+            label="Titre"
+            hint="Choisissez un titre pour votre rapport de bogue"
+            placeholder="bogue: "
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-textarea
+            id="currentBehavior"
+            name="currentBehavior"
+            label="Comportement observé"
+            hint="Décrivez le comportement actuel"
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="expectedBehavior"
+            name="expectedBehavior"
+            label="Comportement attendu"
+            hint="Décrivez le comportement attendu"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="systemInfo"
+            name="systemInfo"
+            label="Information sur le système"
+            hint="Fournir des informations sur votre système"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-textarea
+            id="stepsToReproduce"
+            name="stepsToReproduce"
+            label="Étapes pour reproduire le bogue"
+            hint="Listez les étapes pour reproduire le bogue"
+            required
+            validate-on="submit"
+          ></gcds-textarea>
+
+          <gcds-input
+            id="codeReproductionUrl"
+            name="codeReproductionUrl"
+            type="url"
+            label="URL de reproduction du code"
+            hint="Fournir une URL pour la reproduction du code"
+            required
+            validate-on="submit"
+          ></gcds-input>
+
+          <gcds-textarea
+            id="additionalInfo"
+            name="additionalInfo"
+            label="Informations supplémentaires"
+            hint="Fournir des informations supplémentaires"
+          ></gcds-textarea>
+
+          <gcds-button type="submit">Envoyer</gcds-button>
+        </form>
+      </section>
+
+      <!-- Vue de confirmation affichée par report-a-bug.js après une soumission valide. -->
+      <div id="confirmation" hidden>
+        <gcds-heading tag="h2">Confirmation</gcds-heading>
+        <gcds-text>
+          <strong>
+            Paquet et version des composants de Système de design GC:
+          </strong>
+          <span data-confirm="version"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Titre:</strong> <span data-confirm="title"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Comportement observé:</strong>
+          <span data-confirm="currentBehavior"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Comportement attendu:</strong>
+          <span data-confirm="expectedBehavior"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Information sur le système:</strong>
+          <span data-confirm="systemInfo"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Étapes pour reproduire le bogue:</strong>
+          <span data-confirm="stepsToReproduce"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>URL de reproduction du code:</strong>
+          <span data-confirm="codeReproductionUrl"></span>
+        </gcds-text>
+        <gcds-text>
+          <strong>Informations supplémentaires:</strong>
+          <span data-confirm="additionalInfo"></span>
+        </gcds-text>
+
+        <gcds-heading tag="h2">Créer un ticket sur Github</gcds-heading>
+        <gcds-button
+          id="github-issue-link"
+          href="#"
+          type="link"
+          target="_blank"
+        >
+          Ouvrir un ticket sur Github
+        </gcds-button>
+      </div>
+
+      <!-- TODO : Mettre à jour la date pour qu'elle reflète le changement le plus récent de la page. -->
+      <gcds-date-modified>04-08-2026</gcds-date-modified>
+    </gcds-container>
+
+    <!---------- Pied de page ---------->
+    <!-- TODO: Ajoutez les attributs contextual-heading et contextual-links si votre site utilise un pied de page contextuel. -->
+    <gcds-footer display="full"></gcds-footer>
+
+    <script src="../../report-a-bug.js"></script>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/index.html
+++ b/starter-apps/html/html-basic-template/index.html
@@ -1,0 +1,21 @@
+<!-- TODO: Remove all comments before deploying your code to production. -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!-- TODO: This root page just redirects to the default locale (English).
+      Real deployments usually handle this at the server/host level (e.g. a
+      redirect rule) instead of a meta-refresh — this is here so the
+      starter works out of the box on any static host, including
+      file://. -->
+    <meta http-equiv="refresh" content="0; url=en/" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <p>
+      Redirecting to <a href="en/">the English site</a> — si vous êtes redirigé
+      automatiquement vers l'anglais, vous pouvez aussi consulter
+      <a href="fr/">le site en français</a>.
+    </p>
+  </body>
+</html>

--- a/starter-apps/html/html-basic-template/report-a-bug.js
+++ b/starter-apps/html/html-basic-template/report-a-bug.js
@@ -1,0 +1,70 @@
+/* TODO: This script handles both en/report-a-bug/index.html and
+  fr/signaler-un-bug/index.html. They share the same field ids, so one
+  script handles both languages. If you rename a field, update it here too. */
+(function () {
+  var form = document.querySelector('form[name="bugReportForm"]');
+  if (!form) return;
+
+  var confirmation = document.getElementById("confirmation");
+
+  var FIELD_IDS = [
+    "version",
+    "title",
+    "currentBehavior",
+    "expectedBehavior",
+    "systemInfo",
+    "stepsToReproduce",
+    "codeReproductionUrl",
+    "additionalInfo",
+  ];
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    if (!form.checkValidity()) return;
+    showConfirmation();
+  });
+
+  function fieldValue(id) {
+    var el = document.getElementById(id);
+    return el ? el.value : "";
+  }
+
+  function showConfirmation() {
+    FIELD_IDS.forEach(function (id) {
+      var target = document.querySelector('[data-confirm="' + id + '"]');
+      if (target) target.textContent = fieldValue(id);
+    });
+
+    var githubLink = document.getElementById("github-issue-link");
+    if (githubLink) githubLink.setAttribute("href", buildGithubIssueUrl());
+
+    form.hidden = true;
+    if (confirmation) confirmation.hidden = false;
+  }
+
+  /* TODO: Update the repo/template if you're pointing this at your own
+    project's issue tracker instead of gcds-components. */
+  function buildGithubIssueUrl() {
+    var params = {
+      title: fieldValue("title"),
+      package_version: fieldValue("version"),
+      current_behavior: fieldValue("currentBehavior"),
+      expected_behavior: fieldValue("expectedBehavior"),
+      sys_info: fieldValue("systemInfo"),
+      steps_to_reproduce: fieldValue("stepsToReproduce"),
+      code_url: fieldValue("codeReproductionUrl"),
+      more_info: fieldValue("additionalInfo"),
+    };
+
+    var query = Object.keys(params)
+      .map(function (key) {
+        return key + "=" + encodeURIComponent(params[key]);
+      })
+      .join("&");
+
+    return (
+      "https://github.com/cds-snc/gcds-components/issues/new?template=bug_report.yml&" +
+      query
+    );
+  }
+})();


### PR DESCRIPTION
## ⚠️ PR NEEDS FRENCH TRANSLATIONS FOR NEW READMES

# Summary | Résumé

Adds a new plain HTML starter app (`starter-apps/html/html-basic-template`) with no build step, bundler, or npm install. GCDS components load directly from the CDN. Content and route structure (Home, About, About/Topic, Report a Bug, Not Found, EN/FR) match the existing React and Vue starter apps. The basic HTML staer app is not yet wired into the `create-gcds-app` CLI which will be done in a separate PR once this merges to main, matching how the React starter was built.

# Test instructions | Instructions pour tester la modification

Note: Before testing, check for the newest published versions of `@gcds-core/components` and `@gcds-core/css-shortcuts` and update the CDN version numbers across the HTML files.

1. Check out this branch.
2. Open `starter-apps/html/html-basic-template/en/index.html` directly in your browser.
3. Click through the nav: Home → About → Topic, and confirm the breadcrumbs update correctly (Home only on About/Report a Bug, Home + About on Topic).
4. Click the language toggle in the header and confirm you land on the equivalent French page for whichever page you're on.
5. On the Report a Bug page, submit with required fields empty and confirm the error summary appears and blocks submission.
6. Fill in all fields and submit. Confirm the confirmation view appears with your entered values, and the "Open issue on Github" button links to a GitHub new-issue page with those values pre-filled (no need to actually create the issue).
7. Repeat step 5–6 on the French page (fr/signaler-un-bug/) to confirm the shared report-a-bug.js script works correctly for both languages.
8. Optional: compare page content/copy against the React and Vue starters to confirm consistency.
